### PR TITLE
Quick fixup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -159,9 +159,13 @@ Steps to custom build a version of the pgsql-listen-exchange plugin:
 
     git clone https://github.com/rabbitmq/rabbitmq-public-umbrella
     cd rabbitmq-public-umbrella
+    git checkout rabbitmq_v3_5_4
     make co
     make BRANCH=rabbitmq_v3_5_4 up_c
     git clone https://github.com/gmr/epgsql-wrapper.git
     git clone https://github.com/aweber/pgsql-listen-exchange.git
-    cd rabbitmq-pgsql-listen-exchange
+    cd pgsql-listen-exchange
     make
+
+Currently these steps work in Debian 8 (jessie), using the erlang's 
+packets from its official repository (as `erlang-dev` and `erlang-src`)

--- a/include/pgsql_listen.hrl
+++ b/include/pgsql_listen.hrl
@@ -17,6 +17,8 @@
 -define(DEFAULT_USER, <<"postgres">>).
 -define(DEFAULT_PASSWORD, <<"">>).
 -define(DEFAULT_DBNAME, <<"postgres">>).
+-define(DEFAULT_SSL, true).
+-define(DEFAULT_SSL_OPTS, <<"{verify, verify_none}">>).
 
 -record(pgsql_listen_conn, {pid, server, dbname}).
 -record(pgsql_listen_dsn, {host, port, user, password, dbname}).

--- a/include/pgsql_listen.hrl
+++ b/include/pgsql_listen.hrl
@@ -17,8 +17,8 @@
 -define(DEFAULT_USER, <<"postgres">>).
 -define(DEFAULT_PASSWORD, <<"">>).
 -define(DEFAULT_DBNAME, <<"postgres">>).
--define(DEFAULT_SSL, true).
--define(DEFAULT_SSL_OPTS, <<"{verify, verify_none}">>).
+-define(DEFAULT_SSL, false).
+-define(DEFAULT_SSL_OPTS, <<"{}">>).
 
 -record(pgsql_listen_conn, {pid, server, dbname}).
 -record(pgsql_listen_dsn, {host, port, user, password, dbname}).

--- a/include/pgsql_listen.hrl
+++ b/include/pgsql_listen.hrl
@@ -21,7 +21,7 @@
 -define(DEFAULT_SSL_OPTS, <<"{}">>).
 
 -record(pgsql_listen_conn, {pid, server, dbname}).
--record(pgsql_listen_dsn, {host, port, user, password, dbname}).
+-record(pgsql_listen_dsn, {host, port, user, password, dbname, ssl, ssl_opts}).
 -record(pgsql_listen_state, {amqp, channels, pgsql}).
 -record(properties, {app_id, content_type, content_encoding, delivery_mode,
                      headers, priority, reply_to, type}).

--- a/src/pgsql_listen_db.erl
+++ b/src/pgsql_listen_db.erl
@@ -48,7 +48,7 @@ connect(#pgsql_listen_dsn{host=Host, port=Port, user=User,
 %% @end
 %%
 listen(Connection, Channel) ->
-  query(Connection, "LISTEN " ++ Channel).
+  query(Connection, "LISTEN \"" ++ Channel ++ "\"").
 
 %% @spec unlisten(Connection, Channel) -> Result
 %% @where

--- a/src/pgsql_listen_db.erl
+++ b/src/pgsql_listen_db.erl
@@ -38,9 +38,9 @@ connect(#pgsql_listen_dsn{host=Host, port=Port, user=User,
    epgsql:connect(Host, User, Password, [{database, DBName},
                                          {port, Port},
                                          {timeout, 2500},
-                                         {async, self()},
                                          {ssl, SSL},
-                                         {ssl_opts, SSL_opts}]).
+                                         {ssl_opts, SSL_opts},
+                                         {async, self()}]).
 
 %% @spec listen(Connection, Channel) -> Result
 %% @where

--- a/src/pgsql_listen_db.erl
+++ b/src/pgsql_listen_db.erl
@@ -37,7 +37,9 @@ connect(#pgsql_listen_dsn{host=Host, port=Port, user=User,
    epgsql:connect(Host, User, Password, [{database, DBName},
                                          {port, Port},
                                          {timeout, 2500},
-                                         {async, self()}]).
+                                         {async, self()},
+                                         {ssl, true},
+                                         {ssl_opts, {verify, verify_none}}]).
 
 %% @spec listen(Connection, Channel) -> Result
 %% @where

--- a/src/pgsql_listen_db.erl
+++ b/src/pgsql_listen_db.erl
@@ -33,13 +33,14 @@ close(Conn) ->
 %% @end
 %%
 connect(#pgsql_listen_dsn{host=Host, port=Port, user=User,
-                          password=Password, dbname=DBName}) ->
+                          password=Password, dbname=DBName,
+                          ssl=SSL, ssl_opts=SSL_opts}) ->
    epgsql:connect(Host, User, Password, [{database, DBName},
                                          {port, Port},
                                          {timeout, 2500},
                                          {async, self()},
-                                         {ssl, true},
-                                         {ssl_opts, {verify, verify_none}}]).
+                                         {ssl, SSL},
+                                         {ssl_opts, SSL_opts}]).
 
 %% @spec listen(Connection, Channel) -> Result
 %% @where

--- a/src/pgsql_listen_lib.erl
+++ b/src/pgsql_listen_lib.erl
@@ -20,7 +20,9 @@
          validate_pgsql_port/1,
          validate_pgsql_dbname/1,
          validate_pgsql_user/1,
-         validate_pgsql_password/1]).
+         validate_pgsql_password/1,
+         validate_pgsql_ssl/1,
+         validate_pgsql_ssl_opts/1]).
 
 -include_lib("amqp_client/include/amqp_client.hrl").
 

--- a/src/pgsql_listen_lib.erl
+++ b/src/pgsql_listen_lib.erl
@@ -226,6 +226,32 @@ validate_pgsql_user(none) ->
 validate_pgsql_user(Value) ->
   validate_binary_or_none("pgsql-listen-user", Value).
 
+%% @spec validate_pgsql_ssl(Value) -> Result
+%% @where
+%%       Value  = boolean|none
+%%       Result = ok|{error, Error}
+%% @doc Validate the user specified PostgreSQL SSL is a boolean or none
+%% @end
+%%
+validate_pgsql_ssl(none) ->
+  ok;
+validate_pgsql_ssl(Value) when is_boolean(Value) ->
+  ok;
+validate_pgsql_ssl(Value) ->
+  {error, "pgsql-listen-ssl should be a boolean, actually was ~p", [Value]}.
+
+%% @spec validate_pgsql_ssl_opts(Value) -> Result
+%% @where
+%%       Value  = binary()|none
+%%       Result = ok|{error, Error}
+%% @doc Validate the user specified PostgreSQL ssl_opts is a binary value or none
+%% @end
+%%
+validate_pgsql_ssl_opts(none) ->
+  ok;
+validate_pgsql_ssl_opts(Value) ->
+  validate_binary_or_none("pgsql-listen-ssl-opts", Value).
+
 %% ---------------
 %% Private Methods
 %% ---------------

--- a/src/pgsql_listen_lib.erl
+++ b/src/pgsql_listen_lib.erl
@@ -528,8 +528,12 @@ get_pgsql_port(_) ->
 %% @doc Return the value passed in as a tuple of SSL options for epgsql
 %% @end
 %%
-get_pgsql_ssl_opts(Value) ->
-  {ok, Scanned, _} = erl_scan:string(binary_to_list(Value)),
+get_pgsql_ssl_opts(Value) when is_binary(Value) ->
+  List = if
+    is_binary(Value) -> binary_to_list(Value);
+    true -> Value
+  end,
+  {ok, Scanned, _} = erl_scan:string(List),
   {ok, Parsed} = erl_parse:parse_term(Scanned ++ [{dot,0}]),
   Parsed.
 

--- a/src/pgsql_listen_lib.erl
+++ b/src/pgsql_listen_lib.erl
@@ -492,9 +492,7 @@ get_pgsql_dsn(X) ->
   Password = get_param(X, "password", ?DEFAULT_PASSWORD),
   DBName = get_param(X, "dbname", ?DEFAULT_DBNAME),
   SSL = get_param(X, "ssl", ?DEFAULT_SSL),
-  SSL_opts_string = get_param(X, "ssl-opts", ?DEFAULT_SSL_OPTS),
-  {ok, SSL_opts_scanned, _} = erl_scan:string(binary_to_list(SSL_opts_string)),
-  {ok, SSL_opts} = erl_parse:parse_term(SSL_opts_scanned ++ [{dot,0}]),
+  SSL_opts = get_pgsql_ssl_opts(get_param(X, "ssl-opts", ?DEFAULT_SSL_OPTS)),
   #pgsql_listen_dsn{host=Host, port=Port, user=User, password=Password,
                     dbname=DBName, ssl=SSL, ssl_opts=SSL_opts}.
 
@@ -522,6 +520,18 @@ get_pgsql_port(Value) when is_number(Value) ->
   Value;
 get_pgsql_port(_) ->
   5432.
+
+%% @private
+%% @spec get_pgsql_ssl_opts(Value) -> tuple()
+%% @where
+%%       Value = binary()
+%% @doc Return the value passed in as a tuple of SSL options for epgsql
+%% @end
+%%
+get_pgsql_ssl_opts(Value) ->
+  {ok, Scanned, _} = erl_scan:string(binary_to_list(Value)),
+  {ok, Parsed} = erl_parse:parse_term(Scanned ++ [{dot,0}]),
+  Parsed.
 
 %% @private
 %% @spec is_pgsql_listen_exchange(Exchange) -> Result

--- a/src/pgsql_listen_lib.erl
+++ b/src/pgsql_listen_lib.erl
@@ -83,7 +83,7 @@ publish_notification(Conn, Channel, Payload, State) ->
 
   Properties = #properties{content_encoding=get_binding_longstr(Key, Channel, <<"content_encoding">>),
                            content_type=get_binding_longstr(Key, Channel, <<"content_type">>),
-                           delivery_mode=get_delivery_mode(Key, Channel),
+                           delivery_mode=2,
                            headers=Headers,
                            priority=get_binding_long(Key, Channel, <<"priority">>),
                            reply_to=get_binding_longstr(Key, Channel, <<"reply_to">>),

--- a/src/pgsql_listen_lib.erl
+++ b/src/pgsql_listen_lib.erl
@@ -463,8 +463,12 @@ get_pgsql_dsn(X) ->
   User = get_param(X, "user", ?DEFAULT_USER),
   Password = get_param(X, "password", ?DEFAULT_PASSWORD),
   DBName = get_param(X, "dbname", ?DEFAULT_DBNAME),
+  SSL = get_param(X, "ssl", ?DEFAULT_SSL),
+  SSL_opts_string = get_param(X, "ssl-opts", ?DEFAULT_SSL_OPTS),
+  {ok, SSL_opts_scanned, _} = erl_scan:string(binary_to_list(SSL_opts_string)),
+  {ok, SSL_opts} = erl_parse:parse_term(SSL_opts_scanned ++ [{dot,0}]),
   #pgsql_listen_dsn{host=Host, port=Port, user=User, password=Password,
-                    dbname=DBName}.
+                    dbname=DBName, ssl=SSL, ssl_opts=SSL_opts}.
 
 %% @private
 %% @spec get_pgsql_server(DSN) -> binary()

--- a/src/pgsql_listen_lib.erl
+++ b/src/pgsql_listen_lib.erl
@@ -528,7 +528,7 @@ get_pgsql_port(_) ->
 %% @doc Return the value passed in as a tuple of SSL options for epgsql
 %% @end
 %%
-get_pgsql_ssl_opts(Value) when is_binary(Value) ->
+get_pgsql_ssl_opts(Value) ->
   List = if
     is_binary(Value) -> binary_to_list(Value);
     true -> Value

--- a/src/pgsql_listen_parameters.erl
+++ b/src/pgsql_listen_parameters.erl
@@ -20,7 +20,9 @@
          {policy_validator,  <<"pgsql-listen-port">>},
          {policy_validator,  <<"pgsql-listen-dbname">>},
          {policy_validator,  <<"pgsql-listen-user">>},
-         {policy_validator,  <<"pgsql-listen-password">>}]).
+         {policy_validator,  <<"pgsql-listen-password">>},
+         {policy_validator,  <<"pgsql-listen-ssl">>},
+         {policy_validator,  <<"pgsql-listen-ssl-opts">>}]).
 
 -rabbit_boot_step({?MODULE,
                    [{description, "pgsql-listen parameters"},
@@ -45,16 +47,22 @@ validate_policy(KeyList) ->
   DBName   = proplists:get_value(<<"pgsql-listen-dbname">>, KeyList, none),
   User     = proplists:get_value(<<"pgsql-listen-user">>, KeyList, none),
   Password = proplists:get_value(<<"pgsql-listen-password">>, KeyList, none),
+  SSL      = proplists:get_value(<<"pgsql-listen-ssl">>, KeyList, none),
+  SSL_opts = proplists:get_value(<<"pgsql-listen-ssl-opts">>, KeyList, none),
   Validation = [pgsql_listen_lib:validate_pgsql_host(Host),
                 pgsql_listen_lib:validate_pgsql_port(Port),
                 pgsql_listen_lib:validate_pgsql_dbname(DBName),
                 pgsql_listen_lib:validate_pgsql_user(User),
-                pgsql_listen_lib:validate_pgsql_password(Password)],
+                pgsql_listen_lib:validate_pgsql_password(Password),
+                pgsql_listen_lib:validate_pgsql_ssl(SSL),
+                pgsql_listen_lib:validate_pgsql_ssl_opts(SSL_opts)],
   case Validation of
-    [ok, ok, ok, ok, ok]                   -> ok;
-    [{error, Error, Args}, _, _, _, _]     -> {error, Error, Args};
-    [ok, {error, Error, Args}, _, _, _]    -> {error, Error, Args};
-    [ok, ok, {error, Error, Args}, _, _]   -> {error, Error, Args};
-    [ok, ok, ok, {error, Error, Args}, _]  -> {error, Error, Args};
-    [ok, ok, ok, ok, {error, Error, Args}] -> {error, Error, Args}
+    [ok, ok, ok, ok, ok, ok, ok]                   -> ok;
+    [{error, Error, Args}, _, _, _, _, _, _]       -> {error, Error, Args};
+    [ok, {error, Error, Args}, _, _, _, _, _]      -> {error, Error, Args};
+    [ok, ok, {error, Error, Args}, _, _, _, _]     -> {error, Error, Args};
+    [ok, ok, ok, {error, Error, Args}, _, _, _]    -> {error, Error, Args};
+    [ok, ok, ok, ok, {error, Error, Args}, _, _]   -> {error, Error, Args};
+    [ok, ok, ok, ok, ok, {error, Error, Args}, _]  -> {error, Error, Args};
+    [ok, ok, ok, ok, ok, ok, {error, Error, Args}] -> {error, Error, Args}
   end.

--- a/test/src/pgsql_listen_exchange_tests.erl
+++ b/test/src/pgsql_listen_exchange_tests.erl
@@ -8,4 +8,6 @@ validate_policy_ok_test() ->
              {<<"pgsql-listen-dbname">>, <<"dbname">>},
              {<<"pgsql-listen-user">>, <<"user">>},
              {<<"pgsql-listen-password">>, <<"password">>}],
+             {<<"pgsql-listen-ssl">>, true},
+             {<<"pgsql-listen-ssl-opts">>, <<"{verify,verify_none}">>}],
   ?assertEqual(ok, pgsql_listen_parameters:validate_policy(KeyList)).


### PR DESCRIPTION
This changes let us to:
- Use uppercase in the notify's channels
- All message are persistent by default
- It will use SSL like `psql' sslmode=require`